### PR TITLE
Flash target now gives workers application sandbox privileges in AIR

### DIFF
--- a/net/rezmason/utils/workers/BasicBoss.hx
+++ b/net/rezmason/utils/workers/BasicBoss.hx
@@ -37,7 +37,7 @@ class BasicBoss<TInput, TOutput> {
 
     public function new(core:Core<TInput, TOutput>):Void {
         #if flash
-            worker = WorkerDomain.current.createWorker(core.getData());
+            worker = WorkerDomain.current.createWorker(core.getData(), true);
             incoming = worker.createMessageChannel(Worker.current);
             outgoing = Worker.current.createMessageChannel(worker);
             worker.setSharedProperty('incoming', outgoing);


### PR DESCRIPTION
From Adobe's `WorkerDomain.createWorker()` [documentation](http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/WorkerDomain.html#createWorker%28%29):

 indicates whether the worker should be given application sandbox privileges in AIR. This parameter is ignored in Flash Player 

The worker will now have access to AIR specific functionality like file operations etc...